### PR TITLE
show project metadata not just id

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -682,7 +682,7 @@ async function listAvailableProjects(): Promise<string[]> {
   
   try {
     const [projects] = await projectsClient.searchProjects();
-    return projects.map((p: any) => p.projectId);
+    return projects.map((p: any) => JSON.stringify(p));
   } catch (error) {
     console.error('Error listing projects:', error);
     return [];


### PR DESCRIPTION
A small change to show all project metadata info, not just project id. This can be a bit more useful

<img width="783" alt="image" src="https://github.com/user-attachments/assets/6ecfdbcc-f3a7-49cf-a37a-4a2562c5a861" />

What will be even better (TODO) is to get the project owner and billing. There is a shell script at https://stackoverflow.com/questions/56668098/getting-a-list-of-all-project-owners-from-gcp/79597308#79597308